### PR TITLE
Add CollectionNameResolver tests and improve documentation

### DIFF
--- a/src/MongoMigrations.Test/Collections/CollectionNameResolverTest.cs
+++ b/src/MongoMigrations.Test/Collections/CollectionNameResolverTest.cs
@@ -1,0 +1,48 @@
+using System;
+using FluentAssertions;
+using MongoMigrations.Collections;
+using Xunit;
+
+namespace MongoMigrations.Test.Collections
+{
+    public class CollectionNameResolverTest
+    {
+        private ICollectionNameResolver sut = new CollectionNameResolver();
+        
+        [Fact]
+        public void ShouldBeAbleToMapTypeToCollectionName()
+        {
+            sut.AddType(typeof(TestEntity), "TestEntityCollection");
+
+            var actual = sut.GetCollectionName(typeof(TestEntity));
+
+            actual.Should().Be("TestEntityCollection");
+        }
+
+        [Fact]
+        public void ShouldBeAbleToGetTypeWithGenerics()
+        {
+            sut.AddType(typeof(TestEntity), "TestEntityCollection");
+
+            var actual = sut.GetCollectionName<TestEntity>();
+
+            actual.Should().Be("TestEntityCollection");
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionIfTypeNotMapped()
+        {
+            Func<string> actual = () => sut.GetCollectionName<TestEntity>();
+
+            actual.Should().Throw<MissingDbCollectionConfigurationException>();
+        }
+
+        [Fact]
+        public void ShouldNotAllowEmptyCollectionName()
+        {
+            Func<ICollectionNameResolver> actual = () => sut.AddType(typeof(TestEntity), "");
+
+            actual.Should().Throw<ArgumentException>();
+        }
+    }
+}

--- a/src/MongoMigrations.Test/MongoMigrations.Test.csproj
+++ b/src/MongoMigrations.Test/MongoMigrations.Test.csproj
@@ -30,4 +30,6 @@
       <ProjectReference Include="..\MongoMigrations\MongoMigrations.csproj" />
     </ItemGroup>
 
+
+
 </Project>

--- a/src/MongoMigrations/Collections/CollectionNameResolver.cs
+++ b/src/MongoMigrations/Collections/CollectionNameResolver.cs
@@ -16,11 +16,16 @@ namespace MongoMigrations.Collections
                 return name;
             }
 
-            throw new MissingDbCollectionConfiguration(entityType.ToString());
+            throw new MissingDbCollectionConfigurationException(entityType.ToString());
         }
 
         public ICollectionNameResolver AddType(Type type, string collectionName)
         {
+            if (string.IsNullOrEmpty(collectionName))
+            {
+                throw new ArgumentException("cannot be null or empty", nameof(collectionName));
+            }
+            
             this.collectionNames.Add(type, collectionName);
             return this;
         }

--- a/src/MongoMigrations/Collections/ICollectionNameResolver.cs
+++ b/src/MongoMigrations/Collections/ICollectionNameResolver.cs
@@ -7,9 +7,21 @@ namespace MongoMigrations.Collections
     /// </summary>
     public interface ICollectionNameResolver
     {
-        string? GetCollectionName<T>();
+        /// <summary>
+        /// Get the collection name for a type. Throws MissingDbCollectionConfigurationException if type is not mapped
+        /// to a collection.
+        /// </summary>
+        /// <typeparam name="T">Type to look up</typeparam>
+        /// <returns>name of Mongo colleciton</returns>
+        string GetCollectionName<T>();
 
-        string? GetCollectionName(Type entityType);
+        /// <summary>
+        /// Get the collection name for a type. Throws MissingDbCollectionConfigurationException if type is not mapped
+        /// to a collection.
+        /// </summary>
+        /// <param name="entityType">Type to look up</param>
+        /// <returns>name of Mongo colleciton</returns>
+        string GetCollectionName(Type entityType);
 
         /// <summary>
         /// Add a mapping between a Type and a DB collection

--- a/src/MongoMigrations/Collections/MissingDbCollectionConfigurationException.cs
+++ b/src/MongoMigrations/Collections/MissingDbCollectionConfigurationException.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace MongoMigrations.Collections
 {
-    public class MissingDbCollectionConfiguration : Exception
+    public class MissingDbCollectionConfigurationException : Exception
     {
-        public MissingDbCollectionConfiguration(string type) :
+        public MissingDbCollectionConfigurationException(string type) :
             base($"{type} does not have a mapping to a collection name configured")
         {
         }

--- a/src/MongoMigrations/MongoMigrations.csproj
+++ b/src/MongoMigrations/MongoMigrations.csproj
@@ -3,6 +3,14 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Onkey.MongoMigrations</PackageId>
+        <Title>Mongo Migrations</Title>
+        <Authors>OnKey</Authors>
+        <Description>Provides the ability to migrate Mongo DB documents and databases as the schema evolves</Description>
+        <PackageProjectUrl>https://github.com/OnKey/MongoMigrations</PackageProjectUrl>
+        <PackageLicenseUrl></PackageLicenseUrl>
+        <RepositoryUrl>https://github.com/OnKey/MongoMigrations</RepositoryUrl>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,5 +18,8 @@
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
         <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
     </ItemGroup>
-    
+
+    <PropertyGroup>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
The exception thrown when a type is not mapped to a collection has been renamed from `MissingDbCollectionConfiguration` to `MissingDbCollectionConfigurationException` for clearer communication of its purpose. The terms used in `ICollectionNameResolver` interface methods have also been clarified.

Furthermore, logic has been added in `CollectionNameResolver.cs` to throw an `ArgumentException` when attempting to assign an empty string as a collection name to a type.